### PR TITLE
Add drop_na+maxgap support to regrid1d

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,12 +6,13 @@ Current
 
 New features
 ------------
+- Add the `drop_na` and `maxgap` parameters to the :func:`xoa.regrid.regrid1d` function to fill gaps [:pull:`92`].
 - Add the :func:`xoa.filter.tidal_filter` function to apply a tidal filter to time serie [:pull:`87`].
 
 Breaking changes
 ----------------
 - :func:`xoa.filter.tidal_filter` raises an :class:`~xoa.XoaError` instead of a simple warning when the time step is greater than an hour.
-- :func:`xoa.regrid.regrid1d`: extrapolation from input data instead of output data
+- :func:`xoa.regrid.regrid1d`: extrapolation from input data instead of output data [:pull:`91`].
 
 Deprecations
 ------------

--- a/xoa/__init__.py
+++ b/xoa/__init__.py
@@ -2,10 +2,8 @@
 # -*- coding: utf-8 -*-
 """
 xarray-based ocean analysis library
-
-The successor of Vacumm.
 """
-# Copyright 2020-2021 Shom
+# Copyright 2020-2024 Shom
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/xoa/tests/test_interp.py
+++ b/xoa/tests/test_interp.py
@@ -12,7 +12,7 @@ from xoa import interp
 
 def vfunc(t=0, z=0, y=0, x=0):
     """A function that returns a linear combination of coordinates"""
-    return 1.13 * x + 2.35 * y + 3.24 * z - 0.65 * t
+    return 1.13 * x + 12.35 * y + 3.24 * z - 0.65 * t
 
 
 def round_as_time(arr, units="us", origin="1950-01-01"):
@@ -34,7 +34,6 @@ def get_interp1d_data(
     nyo=25,
     mask=True,
 ):
-
     np.random.seed(0)
 
     # coords
@@ -64,7 +63,6 @@ def get_interp1d_data(
 
 
 def test_interp_nearest1d():
-
     # Get data
     xxi, yyi, vari, xxo, yyo, eshapes = get_interp1d_data()
 
@@ -78,7 +76,6 @@ def test_interp_nearest1d():
 
 
 def test_interp_linear1d():
-
     # Get data
     xxi, yyi, vari, xxo, yyo, eshapes = get_interp1d_data()
 
@@ -91,7 +88,6 @@ def test_interp_linear1d():
 
 
 def test_interp_cubic1d():
-
     # Get data
     xxi, yyi, vari, xxo, yyo, eshapes = get_interp1d_data()
 
@@ -103,7 +99,6 @@ def test_interp_cubic1d():
 
 
 def test_interp_hermit1d():
-
     # Get data
     xxi, yyi, vari, xxo, yyo, eshapes = get_interp1d_data()
 
@@ -116,7 +111,6 @@ def test_interp_hermit1d():
 
 @pytest.mark.parametrize("method", ["nearest", "linear", "cubic", "hermit"])
 def test_interp1d_nans_in_coords(method):
-
     # Get data
     xxi, yyi, vari, xxo, yyo, eshapes = get_interp1d_data()
 
@@ -135,9 +129,22 @@ def test_interp1d_nans_in_coords(method):
     np.testing.assert_allclose(varol, varoln[:, 3:-3])
 
 
+def test_linear1d_drop_na():
+    # Get data
+    xxi, yyi, vari, xxo, yyo, eshapes = get_interp1d_data(yomax=-20)
+
+    varo = interp.linear1d(vari, yyi, yyo, eshapes, drop_na=True)
+    assert not np.isnan(varo).any()
+    varo_true = vfunc(y=yyo, x=xxo)
+    np.testing.assert_allclose(varo_true, varo)
+
+    varo0 = interp.linear1d(vari, yyi, yyo, eshapes, drop_na=False)
+    varo1 = interp.linear1d(vari, yyi, yyo, eshapes, drop_na=True, maxgap=1)
+    np.testing.assert_allclose(varo0, varo1)
+
+
 @pytest.mark.parametrize("method", ["nearest", "linear", "cubic", "hermit"])
 def test_interp_interp1d_eshapes(method):
-
     # Get data and func
     xxi, yyi, vari, xxo, yyo, eshapes = get_interp1d_data(nx=18, mask=False, irregular=False)
     eshapes = np.repeat([[3, 6]], 3, axis=0)
@@ -192,7 +199,6 @@ def test_interp_interp1d_eshapes(method):
 
 
 def test_interp_cellave1d():
-
     np.random.seed(0)
 
     # coords
@@ -240,7 +246,6 @@ def test_interp_cellave1d():
     ],
 )
 def test_interp_cell2relloc(x, y, pt, qt):
-
     x1, y1 = 0.0, 0.0
     x2, y2 = 3.0, 1.0
     x3, y3 = 2.0, 3.0
@@ -252,7 +257,6 @@ def test_interp_cell2relloc(x, y, pt, qt):
 
 @functools.lru_cache()
 def get_grid2locs_coords(nex=4, nexz=2, nxi=7, nyi=6, nzi=5, nti=4, no=10):
-
     np.random.seed(0)
 
     tti, zzi, yyi, xxi = np.mgrid[
@@ -278,7 +282,6 @@ def get_grid2locs_coords(nex=4, nexz=2, nxi=7, nyi=6, nzi=5, nti=4, no=10):
 
 
 def test_interp_grid2locs():
-
     # Multi-dimensional generic coordinates
     nex = 4
     nexz = 2
@@ -375,7 +378,6 @@ def test_interp_grid2locs():
 
 
 def test_interp_isoslice():
-
     depth = np.linspace(-50, 0.0, 6)
     values = np.linspace(10, 20.0, 6)
     isoval = 15.0

--- a/xoa/tests/test_regrid.py
+++ b/xoa/tests/test_regrid.py
@@ -12,7 +12,6 @@ from test_interp import get_grid2locs_coords, vfunc, get_interp1d_data
 
 
 def test_regrid_regrid1d():
-
     # Get some data
     xxi, yyi, vari, xxo, yyo, eshapes = get_interp1d_data()
 
@@ -104,25 +103,14 @@ def test_regrid_extrap1d(mode, expected):
     assert 'z' in vo.coords
 
 
+@pytest.mark.parametrize("method", ["linear", "cubic", "hermit", "nearest"])
 @pytest.mark.parametrize(
-    "method,mode,expected",
+    "mode,expected",
     [
-        ["linear", "both", [1, 1, 1]],
-        ["linear", "bottom", [np.nan, 1, 1]],
-        ["linear", "no", [np.nan, 1, np.nan]],
-        ["linear", "top", [1, 1, np.nan]],
-        ["cubic", "both", [1, 1, 1]],
-        ["cubic", "bottom", [np.nan, 1, 1]],
-        ["cubic", "no", [np.nan, 1, np.nan]],
-        ["cubic", "top", [1, 1, np.nan]],
-        ["hermit", "both", [1, 1, 1]],
-        ["hermit", "bottom", [np.nan, 1, 1]],
-        ["hermit", "no", [np.nan, 1, np.nan]],
-        ["hermit", "top", [1, 1, np.nan]],
-        ["nearest", "both", [1, 1, 1]],
-        ["nearest", "bottom", [np.nan, 1, 1]],
-        ["nearest", "no", [np.nan, 1, np.nan]],
-        ["nearest", "top", [1, 1, np.nan]],
+        ["both", [1, 1, 1]],
+        ["top", [np.nan, 1, 1]],
+        ["no", [np.nan, 1, np.nan]],
+        ["bottom", [1, 1, np.nan]],
     ],
 )
 def test_regrid_regri1d_extrap(method, mode, expected):
@@ -135,7 +123,6 @@ def test_regrid_regri1d_extrap(method, mode, expected):
 
 
 def test_regrid_grid2loc():
-
     np.random.seed(0)
 
     # Multi-dimensional generic coordinates
@@ -183,7 +170,6 @@ def test_regrid_grid2loc():
 
 
 def test_regrid_isoslice():
-
     depth = xr.DataArray(np.linspace(-50, 0.0, 6), dims="z", attrs={"long_name": "Depth"})
     values = xr.DataArray(np.linspace(10, 20.0, 6), dims="z")
     isoval = 15.0


### PR DESCRIPTION
# Description
This adds the `drop_na` + `maxgap` support to `regrid1d` function for "nearest", "linear", "cubic" and "hermit" methods.
When set to True, `drop_na` force the interpolation to ignore inner gaps smaller than `maxgap`.


# Check list

- [x] Tests added
- [x] User visible changes (including notable bug fixes) are documented in `CHANGES.rst`

