### PR TITLE
Fix grid2loc

### DIFF
--- a/xoa/grid.py
+++ b/xoa/grid.py
@@ -612,7 +612,7 @@ def to_rect(da, tol=1e-5, errors="warn"):
                 "Cannot convert to curvilinear to rectangular grid since since coordinate "
                 f"'{name}' is not constant along one of its dimensions"
             )
-            if errors == "errors":
+            if errors == "raise":
                 raise XoaError(msg)
             elif errors == "ignore":
                 xoa_warn(msg)

--- a/xoa/grid.py
+++ b/xoa/grid.py
@@ -583,7 +583,7 @@ def to_rect(da, tol=1e-5, errors="warn"):
     ------
     xarray.DataArray, xarray.Dataset
     """
-    da = da.copy()
+    #da = da.copy()
     new_coords = {}
     rename_args = {}
     da = cf.infer_coords(da)

--- a/xoa/grid.py
+++ b/xoa/grid.py
@@ -137,7 +137,6 @@ def apply_along_dim(
 
 
 def _pad_(da, dim, pad_width, mode, **kwargs):
-
     pad_width = pad_width.get(dim, 0)
     if not pad_width:
         return da.copy()
@@ -615,7 +614,8 @@ def to_rect(da, tol=1e-5, errors="warn"):
             )
             if errors == "errors":
                 raise XoaError(msg)
-            xoa_warn(msg)
+            elif errors == "ignore":
+                xoa_warn(msg)
     if new_coords:
         return (
             da.reset_coords(list(new_coords), drop=True)

--- a/xoa/interp.py
+++ b/xoa/interp.py
@@ -825,7 +825,7 @@ def grid2rellocs(xxi, yyi, xo, yo):
     return pp, qq
 
 
-@numba.njit(parallel=False, cache=NOT_CI)
+@numba.njit(parallel=True, cache=NOT_CI)
 def grid2locs(xxi, yyi, zzi, ti, vi, xo, yo, zo, to):
     """Linear interpolation of gridded data to random positions
 

--- a/xoa/regrid.py
+++ b/xoa/regrid.py
@@ -484,7 +484,7 @@ def grid2loc(da, loc, compat="warn"):
     glon = xcoords.get_lon(da)  # before to_rect
     glat = xcoords.get_lat(da)  # before to_rect
     dims_in = set(glon.dims).union(glat.dims)
-    da_tmp = xgrid.to_rect(da)
+    da_tmp = xgrid.to_rect(da, errors="ignore")
     da_tmp = xcoords.reorder(da_tmp, order)
 
     # To numpy with singletons


### PR DESCRIPTION
# Description

Fix the case when `errors="raise"` is passed to `xoa.grid.to_rect`: an error is now raised.

